### PR TITLE
Support both x86 and arm Macs

### DIFF
--- a/src/macos-source.env
+++ b/src/macos-source.env
@@ -2,14 +2,16 @@
 #export FARCOCPT_CXX=""       #: select the c++ compiler (default mpic++)
 #export FARCOCPT_CFLAGS=""    #: select additional CFLAGS (default empty)
 
+BREW_PREFIX="$(brew --prefix)"
+
 # use llvm installed with homebrew it supports OpenMP
-export PATH="/usr/local/opt/llvm/bin:$PATH"
+export PATH="$BREW_PREFIX/opt/llvm/bin:$PATH"
 
 # set path to open-mpi dir, run 'brew info open-mpi' to find it
-export MPI_HOME="/usr/local/opt/open-mpi"           #: prefix of the MPI installation (default /usr)
+export MPI_HOME="$BREW_PREFIX/opt/open-mpi"           #: prefix of the MPI installation (default /usr)
 # set path to fftw dir, run 'brew info fftw' to find it
-export FFTW_HOME="/usr/local/opt/fftw"          #: prefix of the FFTW installation (default /usr)
+export FFTW_HOME="$BREW_PREFIX/opt/fftw"          #: prefix of the FFTW installation (default /usr)
 # set path to gsl dir, run 'brew info gsl' to find it
-export GSL_HOME="/usr/local/opt/gsl"         #: prefix of the GSL installation (default /usr)
+export GSL_HOME="$BREW_PREFIX/opt/gsl"         #: prefix of the GSL installation (default /usr)
 # set path to OpenMP dir, run 'brew info libomp' to find it
-export OMP_HOME="/usr/local/opt/libomp"
+export OMP_HOME="$BREW_PREFIX/opt/libomp"


### PR DESCRIPTION
use `brew --prefix` to determine library location

On Macs with the arm M1/M2 chip, homebrew has a different prefix compared to the x86 intel Macs.
This pull request considers this automatically in the env file by using the `brew --prefix` command.