### PR TITLE
Compatibility fixes for WSL

### DIFF
--- a/bin/fargocpt.py
+++ b/bin/fargocpt.py
@@ -53,19 +53,26 @@ def main():
     first_numa_node = [k for k in numa_nodes.keys()][0]
     N_cores_per_numa = len(numa_nodes[first_numa_node])
 
-    if opts.np is None and opts.nt is None:        
-        N_procs = max(1, ncpu//N_cores_per_numa)
-        N_OMP_threads = ncpu//N_procs
-
-    elif opts.np is not None and opts.nt is None:
+    if opts.np is not None and opts.nt is not None:
         N_procs = opts.np
-        N_OMP_threads = N_cores_per_numa
+        N_OMP_threads = opts.nt
     elif opts.np is None and opts.nt is not None:
         N_procs = 1
         N_OMP_threads = opts.nt
+    elif opts.np is None and opts.nt is None:        
+        ncpu = get_num_cores()
+        numa_nodes = get_numa_nodes()
+        first_numa_node = [k for k in numa_nodes.keys()][0]
+        N_cores_per_numa = len(numa_nodes[first_numa_node])
+        N_procs = max(1, ncpu//N_cores_per_numa)
+        N_OMP_threads = ncpu//N_procs
     else:
         N_procs = opts.np
-        N_OMP_threads = opts.nt
+        N_OMP_threads = N_cores_per_numa
+        ncpu = get_num_cores()
+        numa_nodes = get_numa_nodes()
+        first_numa_node = [k for k in numa_nodes.keys()][0]
+        N_cores_per_numa = len(numa_nodes[first_numa_node])
 
     ### TODO: get correct number of cores when hyperthreading is enabled
     if N_OMP_threads == 32: # hack for bwUniCluster icelake nodes

--- a/examples/100_Quickstart.ipynb
+++ b/examples/100_Quickstart.ipynb
@@ -50,7 +50,10 @@
    "id": "40f50bdd-bbeb-4328-9d4e-17c6810b070f",
    "metadata": {},
    "source": [
-    "Make sure the code is built by running make again."
+    "Make sure the code is built by running make again.\n",
+    "\n",
+    "If you have not yet compiled the go, please go to the readme and follow the instructions there.\n",
+    "You can also try to run the following cell directly, but it will only output error messages. This might make debugging harder."
    ]
   },
   {
@@ -196,7 +199,7 @@
    ],
    "source": [
     "cwd = os.getcwd()\n",
-    "cmd = f\"cd {cwd} && ../../run_fargo -np 1 -nt 4 auto {configfile}\"\n",
+    "cmd = f\"cd {cwd} && python3 ../../run_fargo -np 1 -nt 4 auto {configfile}\"\n",
     "print(cmd)"
    ]
   },
@@ -216,7 +219,7 @@
    "outputs": [],
    "source": [
     "# import sys\n",
-    "# sys.path.append(\"code/bin\")\n",
+    "# sys.path.append(\"../../bin\")\n",
     "# from fargocpt import run_fargo\n",
     "# run_fargo(1, 4, [\"start\", configfile])"
    ]
@@ -543,7 +546,7 @@
     }
    ],
    "source": [
-    "!../../Tools/inspect_tab_file.py output/out/monitor/Quantities.dat"
+    "!python3 ../../Tools/inspect_tab_file.py output/out/monitor/Quantities.dat"
    ]
   },
   {
@@ -570,7 +573,7 @@
     }
    ],
    "source": [
-    "!../../Tools/inspect_tab_file.py output/out/monitor/Quantities.dat 2 3 --units kyr solMass | head"
+    "!python3 ../../Tools/inspect_tab_file.py output/out/monitor/Quantities.dat 2 3 --units kyr solMass | head"
    ]
   },
   {
@@ -697,7 +700,7 @@
     "try:\n",
     "    from disgrid import Data\n",
     "except ImportError:\n",
-    "    raise ImportError(\"Please install disgrid with `python3 -m pip install git+https://github.com/rometsch/disgrid\")\n",
+    "    raise ImportError(\"Please install disgrid with `python3 -m pip install git+https://github.com/rometsch/disgrid`\")\n",
     "d = Data(\"output/out\")\n",
     "d.avail()"
    ]


### PR DESCRIPTION
On Windows Subsystem for Linux (WSL) there were two issues:

-  permission issues because of unset executable flags on scripts 
-  the automatic determination of available system cores in the wrapper does not work

The first issues is addressed by calling `!python3 some/script.py` in the notebooks explicitly.
The second issue is alleviated by rearranging the option logic in the wrapper, such that calling with a number of threads, e.g., `./run_fargo -nt 4 ...` work.