### PR TITLE
fix import error in run_fargo

### DIFF
--- a/python_module/fargocpt/__init__.py
+++ b/python_module/fargocpt/__init__.py
@@ -1,3 +1,9 @@
-from .data import Loader
 from .run import run
-from .overview import Overview
+try:
+    from .data import Loader
+except ImportError:
+    pass
+try:
+    from .overview import Overview
+except ImportError:
+    pass

--- a/run_fargo
+++ b/run_fargo
@@ -5,7 +5,11 @@ try:
     from fargocpt.run import main
 except ImportError:
     import sys
-    sys.path.append("../python/")
+    import inspect
+    this_folder = os.path.realpath(os.path.abspath(os.path.split(inspect.getfile( inspect.currentframe() ))[0]))
+    module_folder = os.path.realpath(os.path.abspath(os.path.join(this_folder,"python_module")))
+    sys.path.append(module_folder)
+    print
     from fargocpt.run import main
 
 file_dir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
When the fargocpt module is not installed, it is imported from the path inside the repository.
This was broken.

The path for import was fixed, as well as some import requirements relaxed.
Also a bug was fixed for handling crtl+c.