### PR TITLE
Replaced bitwise or with logical or

### DIFF
--- a/src/SourceEuler.cpp
+++ b/src/SourceEuler.cpp
@@ -619,7 +619,7 @@ void calculate_qplus(t_data &data)
 			viscous_heating(data);
     }
     if (parameters::heating_star_enabled) {
-		if (!(parameters::cooling_surface_enabled | parameters::cooling_scurve_enabled)) {
+		if (!(parameters::cooling_surface_enabled || parameters::cooling_scurve_enabled)) {
 		    compute::kappa_eff(data);
 		}
 		irradiation(data);


### PR DESCRIPTION
Thanks @rometsch for pointing it out.