### PR TITLE
fix nans in Qplus

### DIFF
--- a/src/SourceEuler.cpp
+++ b/src/SourceEuler.cpp
@@ -620,6 +620,7 @@ void calculate_qplus(t_data &data)
     }
     if (parameters::heating_star_enabled) {
 		if (!(parameters::cooling_surface_enabled || parameters::cooling_scurve_enabled)) {
+			compute::midplane_density(data, sim::time);
 		    compute::kappa_eff(data);
 		}
 		irradiation(data);


### PR DESCRIPTION
### Issue
Simulations froze when an ideal equation of state was used and irradiation was the only heating source.

### Cause
The midplane density was not computed before computation of the effective opacity (kappa_eff), so the latter was equal to inf.
Then in computing the Qplus contribution from irradiation, this lead to Qplus being NaN and finally the timestep to be zero due to the nan contribution from the heating and cooling terms.

### Fix
This is fixed by computing midplane density before the effective opacity.