### PR TITLE
fix parameter getter in fld

### DIFF
--- a/src/fld.cpp
+++ b/src/fld.cpp
@@ -137,8 +137,8 @@ void config() {
 	radiative_diffusion_omega, radiative_diffusion_max_iterations);
 
 	// boundary conditions
-	inner_boundary_name = config::cfg.get<std::string>("RadiativeDiffusionInnerBoundary", "none");
-	outer_boundary_name = config::cfg.get<std::string>("RadiativeDiffusionOuterBoundary", "none");
+	inner_boundary_name = config::cfg.get_lowercase("RadiativeDiffusionInnerBoundary", "none");
+	outer_boundary_name = config::cfg.get_lowercase("RadiativeDiffusionOuterBoundary", "none");
 
 	if (radiative_diffusion_enabled) {
 		if (inner_boundary_name == "none") {


### PR DESCRIPTION
There was a bug in getting the boundary condition parameter for FLD.
Now the correct function is used.