### PR TITLE
write default planet config on request

### DIFF
--- a/src/nbody/planetary_system.cpp
+++ b/src/nbody/planetary_system.cpp
@@ -74,6 +74,10 @@ void t_planetary_system::init_system()
     for (auto &planet_cfg : planet_configs) {
 		init_planet(planet_cfg);
     }
+	
+	if (config::cfg.get_flag("WriteDefaultValues", "no")) {
+		planet_configs[0].write_default(output::outdir + "default_config_nbody.yml");
+	}
 
 	if (CPU_Master) {
 		for (auto &planet_cfg : planet_configs) {


### PR DESCRIPTION
When the flag "WriteDefaultValues" is set, write the default parameters for the first Nbody object (solar mass star) to the file `default_config_nbody.yml`.