### PR TITLE
compute Q with OmegaK

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,10 @@ Syntax of the versions are: major, minor, revision
 - minor: new features, new options, new config file options, renamed parameters, new or changed single output files
 - revision: bug fixes
 
+## Version 1.4.1
+- compute Toomre Q with OmegaK instead of epicycle frequency for use in adjusting scaleheight for SG
+- adjust scaleheight in SG runs with Toomre Q
+
 ## Version 1.4
 - rename 'vtheta' and 'vphi' both to 'vazi'. The output file of azimuthal velocity is now called 'vazi.dat' instead of 'vtheta.dat'. You might have to rename files to restart data.
 - executable file renamed from `fargocpt` to `fargocpt_exe` to allow python cli to be called `fargocpt`

--- a/src/compute.cpp
+++ b/src/compute.cpp
@@ -6,6 +6,7 @@
 #include "frame_of_reference.h"
 #include "constants.h"
 #include "global.h"
+#include "Theo.h"
 
 namespace compute {
 
@@ -98,22 +99,15 @@ void toomreQ(t_data &data) {
 	for (unsigned int nr = 1; nr < Nr; ++nr) {
 	for (unsigned int naz = 0; naz < Nphi; ++naz) {
 	    
-		// kappa^2 = 1/r^3 d((r^2 Omega)^2)/dr = 1/r^3 d((r*v_phi)^2)/dr
-		// be sure to compute vaz with the correct frame of reference
-		const double ro = Rmed[nr];
-		const double vo = data[t_data::V_AZIMUTHAL](nr, naz) + ro * refframe::OmegaFrame;
-		const double ri = Rmed[nr - 1];
-		const double vi = data[t_data::V_AZIMUTHAL](nr - 1, naz) + ri * refframe::OmegaFrame;
-        const double kappa = std::sqrt(std::fabs(
-		std::pow(InvRmed[nr], 3) *
-		(std::pow(vo * ro,  2) - std::pow(vi * ri, 2)) * InvDiffRmed[nr]));
+		const double r = Rmed[nr];
+        const double OmegaK = calculate_omega_kepler(r);
 
-	    // Q = (c_s kappa) / (Pi G Sigma)
+	    // Q = (c_s Omega_K) / (Pi G Sigma)
 	    
 		const double cs = data[t_data::SOUNDSPEED](nr, naz);
 		const double G = constants::G;
 		const double Sigma = data[t_data::SIGMA](nr, naz);
-		data[t_data::TOOMRE](nr, naz) = cs * kappa / (M_PI * G * Sigma);
+		data[t_data::TOOMRE](nr, naz) = cs * OmegaK / (M_PI * G * Sigma);
 	}
     }
 }

--- a/src/version.h
+++ b/src/version.h
@@ -7,6 +7,6 @@ namespace version {
 // major: major restructuring of code or config files
 // minor: new features, new options, new config file options, renamed parameters
 // revision: bug fixes, small changes, no config file changes
-const char *string = "1.4.0";
+const char *string = "1.4.1";
 
 }


### PR DESCRIPTION
Toomre Q needs to be computed with OmegaK instead of epicycle frequency for vertical scale height adjustment.