### PR TITLE
78 particlesurfacedensityslope parameter should not be mandatory parameter

### DIFF
--- a/Tools/param_names/parameters.yml
+++ b/Tools/param_names/parameters.yml
@@ -855,10 +855,10 @@ ParticleSpeciesNumber:
   type: unsigned int
   unitsupport: false
 ParticleSurfaceDensitySlope:
-  choices: -0+
-  default: 0
-  description: 'Slope of particle surface density distribution: Sigma(r) = Sigma0 * r^(-ParticleSurfaceDensitySlope). [default = SigmaSlope]'
-  type: double
+  choices: -0+, gas
+  default: SigmaSlope
+  description: Slope of particle surface density distribution: Sigma(r) = Sigma0 * r^(-ParticleSurfaceDensitySlope). [default = SigmaSlope] in case of "gas" particles are inserted into the disk according to the gas mass distribution
+  type: double, string
   unitsupport: false
 PlanetOrbitDiskTest:
   choices: yes, no

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -819,7 +819,7 @@ void read(const std::string &filename, t_data &data)
     particle_density = config::cfg.get<double>("ParticleDensity", "2.65 g/cm3", M0/(L0*L0*L0));
 
     {
-	std::string particle_slope_string = config::cfg.get<std::string>("ParticleSurfaceDensitySlope", "");
+	std::string particle_slope_string = config::cfg.get<std::string>("ParticleSurfaceDensitySlope", "SigmaSlope");
 	if (particle_slope_string == "gas"){
 	    particle_distribution_like_gas = true;
 	} else {

--- a/src/parameters.cpp
+++ b/src/parameters.cpp
@@ -819,7 +819,7 @@ void read(const std::string &filename, t_data &data)
     particle_density = config::cfg.get<double>("ParticleDensity", "2.65 g/cm3", M0/(L0*L0*L0));
 
     {
-	std::string particle_slope_string = config::cfg.get<std::string>("ParticleSurfaceDensitySlope");
+	std::string particle_slope_string = config::cfg.get<std::string>("ParticleSurfaceDensitySlope", "");
 	if (particle_slope_string == "gas"){
 	    particle_distribution_like_gas = true;
 	} else {


### PR DESCRIPTION
ParticleSurfaceDensitySlope was read without a default parameter value which makes it a mandatory parameter.
This merge request fixes the bug.