### PR TITLE
only do H adjustment when SG is turned on

### DIFF
--- a/src/SourceEuler.cpp
+++ b/src/SourceEuler.cpp
@@ -1334,13 +1334,9 @@ void compute_scale_height(t_data &data, const double current_time)
     default:
 	compute_scale_height_old(data);
     }
-
-	//if (parameters::self_gravity) {
-	//	compute::toomreQ(data);
-	//	adjust_scale_height_for_sg(data);
-	//}
 	
-	if (parameters::self_gravity_mode == parameters::t_sg::sg_BK) {
+	if (parameters::self_gravity && 
+		parameters::self_gravity_mode == parameters::t_sg::sg_BK) {
         compute::toomreQ(data);
         adjust_scale_height_for_sg(data);
     }


### PR DESCRIPTION
In merge request #60, adjustment of scaleheight for self gravity was limited to the case that sg mode is bessel kernel.
Because this is the default parameter, the scaleheight was always adjusted with Q, even when sg was not turned on.

The spreading ring test has a high surface density, so low Q, and is affected most strongly.

The fix is to also check for sg being turned on.