### PR TITLE
write particles file when initializing them on restart

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -149,7 +149,11 @@ int main(int argc, char *argv[])
 
 	if (start_mode::mode != start_mode::mode_restart) {
 		sim::handle_outputs(data);
-	}
+	} 
+    if ((start_mode::mode == start_mode::mode_restart || start_mode::mode == start_mode::mode_auto) 
+        && parameters::integrate_particles) {
+        particles::write_if_not_exist();
+    }
 
 	sim::run(data);	
     

--- a/src/particles/particles.cpp
+++ b/src/particles/particles.cpp
@@ -27,6 +27,7 @@
 #include <sstream>
 #include <stdlib.h>
 #include <vector>
+#include <filesystem>
 
 
 namespace particles
@@ -2157,6 +2158,19 @@ void move(void)
     // update global_number_of_particles
     MPI_Allreduce(&local_number_of_particles, &global_number_of_particles, 1,
 		  MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+}
+
+/* Write a particle file if it does not exists in the current snapshot directory
+*/
+void write_if_not_exist() {
+	if (output::is_autosave_dir(output::snapshot_dir)) {
+		die("I refuse to write particle file in autosave directory. This is for your own sanity. Change the code if you really want to initialize particles when restarting from autosave!");
+	}
+	std::string filename = output::snapshot_dir + "/particles.dat";
+	if (!std::filesystem::exists(filename)) {
+		write();
+	}
+	logging::print_master(LOG_INFO "Particle file written to %s\n", filename.c_str());
 }
 
 void write()

--- a/src/particles/particles.h
+++ b/src/particles/particles.h
@@ -48,6 +48,7 @@ void integrate(t_data &data, const double current_time, double dt);
 void integrate_explicit_adaptive(t_data &data, const double dt);
 void integrate_exponential_midpoint(t_data &data, const double dt);
 void write();
+void write_if_not_exist();
 void write_info();
 void move(void);
 void rotate(const double angle);


### PR DESCRIPTION
On restart with the restart or auto flag, a particle file with the initial conditions is written to the snapshot dir from which the simulation is restarted.
If restarted from an autosave directory, the simulation exits, because this is most likely unintended behavior.

Tested with auto and restart mode, tested to fail from autosave. Testsuite run with success.