### PR TITLE
Const cubic smoothing length

### DIFF
--- a/src/Force.cpp
+++ b/src/Force.cpp
@@ -84,7 +84,7 @@ Pair ComputeDiskOnPlanetAccel(t_data &data, const unsigned int nb)
 		/// by Klahr & Kley 2005; but the derivative of it, since we
 		/// apply it directly on the force
 			const double l1 = planet.get_dimensionless_roche_radius() *
-				planet.get_distance_to_primary();
+				planet.get_semi_major_axis() * (1.0 - planet.get_eccentricity());
 			const double r_sm = l1 * klahr_smoothing_constant;
 
 			if (dist_sm < r_sm) {

--- a/src/Pframeforce.cpp
+++ b/src/Pframeforce.cpp
@@ -31,7 +31,7 @@ void CalculateNbodyPotential(t_data &data, const double current_time)
 	g_ypl[k] = planet.get_y();
 
 	g_cubic_smoothing_radius[k] = planet.get_dimensionless_roche_radius() *
-		      planet.get_distance_to_primary() * planet.get_cubic_smoothing_factor();
+		      planet.get_semi_major_axis() * (1.0 - planet.get_eccentricity())  * planet.get_cubic_smoothing_factor();
 
     }
 
@@ -99,7 +99,7 @@ void CalculateAccelOnGas(t_data &data, const double current_time)
 	g_ypl[k] = planet.get_y();
 
 	g_cubic_smoothing_radius[k] = planet.get_dimensionless_roche_radius() *
-				     planet.get_distance_to_primary() * planet.get_cubic_smoothing_factor();
+				     planet.get_semi_major_axis() * (1.0 - planet.get_eccentricity()) * planet.get_cubic_smoothing_factor();
     }
 
     double *acc_r = data[t_data::ACCEL_RADIAL].Field;

--- a/src/SourceEuler.cpp
+++ b/src/SourceEuler.cpp
@@ -553,7 +553,7 @@ static void irradiation_single(t_data &data, const t_planet &planet) {
 	const double T_star = planet.get_temperature();
 
 	const double l1 = planet.get_dimensionless_roche_radius() *
-			planet.get_distance_to_primary();
+			planet.get_semi_major_axis() * (1.0 - planet.get_eccentricity());
 	double min_dist;
 	if(x*x + y*y > 1e-10){
 	    min_dist = std::max(R_star, l1 * planet.get_cubic_smoothing_factor());

--- a/src/accretion.cpp
+++ b/src/accretion.cpp
@@ -112,7 +112,8 @@ static bool AccreteOntoSinglePlanet(t_data &data, t_planet &planet, double dt)
     // W. Kley's parameters initialization finished
 
     const double RHill = planet.get_dimensionless_roche_radius() *
-			 planet.get_distance_to_primary();
+		planet.get_semi_major_axis() * (1.0 - planet.get_eccentricity());
+
     // search radius is bigger fraction + 2 dphi cell sizes to capture all cells
     const double search_radius = RHill * frac1 + 2.0 * Rplanet / ns;
 
@@ -242,7 +243,7 @@ static bool SinkHoleSinglePlanet(t_data &data, t_planet &planet, double dt)
     const double frac = parameters::accretion_radius_fraction;
 
     const double RHill = planet.get_dimensionless_roche_radius() *
-			 planet.get_distance_to_primary();
+			 planet.get_semi_major_axis() * (1.0 - planet.get_eccentricity());
     // search radius is bigger fraction + 2 dphi cell sizes to capture all cells
     const double search_radius = RHill * frac + 2.0 * Rplanet / ns;
 
@@ -358,7 +359,7 @@ static bool AccreteOntoSinglePlanetViscous(t_data &data, t_planet &planet,
     const double frac = parameters::accretion_radius_fraction;
 
     const double RHill = planet.get_dimensionless_roche_radius() *
-			 planet.get_distance_to_primary();
+			 planet.get_semi_major_axis() * (1.0 - planet.get_eccentricity());
     // search radius is bigger fraction + 2 dphi cell sizes to capture all cells
     const double search_radius = RHill * frac + 2.0 * Rplanet / ns;
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -643,7 +643,8 @@ void init_secondary_disk_densities(t_data &data)
     const double mass_q = planet.get_mass() /
 			  data.get_planetary_system().get_planet(0).get_mass();
     const double compute_radius =
-	eggleton_1983(mass_q, planet.get_distance_to_primary());
+	eggleton_1983(mass_q, planet.get_distance_to_primary())
+	* planet.get_semi_major_axis() * (1.0 - planet.get_eccentricity());
     const double scaling_factor = std::sqrt(mass_q);
 
     const double min_dist = RMIN / 3.0;
@@ -700,7 +701,8 @@ void init_secondary_disk_energies(t_data &data)
     const double mass_q = planet.get_mass() /
 			  data.get_planetary_system().get_planet(0).get_mass();
     const double compute_radius =
-	eggleton_1983(mass_q, planet.get_distance_to_primary());
+	eggleton_1983(mass_q, planet.get_distance_to_primary())
+	* planet.get_semi_major_axis() * (1.0 - planet.get_eccentricity());
     const double scaling_factor = std::sqrt(mass_q);
 
     const double min_dist = RMIN / 3.0;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -634,15 +634,17 @@ void init_secondary_disk_densities(t_data &data)
     const auto &planet = data.get_planetary_system().get_planet(1);
     const double disk_size = parameters::profile_cutoff_point_outer *
 			     planet.get_dimensionless_roche_radius() /
-			     (1.0 - planet.get_dimensionless_roche_radius());
+			     (1.0 - planet.get_dimensionless_roche_radius())
+			     * planet.get_semi_major_axis() * (1.0 - planet.get_eccentricity());
     const double cutoff_width = parameters::profile_cutoff_width_outer *
 				planet.get_dimensionless_roche_radius() /
-				(1.0 - planet.get_dimensionless_roche_radius());
+				(1.0 - planet.get_dimensionless_roche_radius())
+				* planet.get_semi_major_axis() * (1.0 - planet.get_eccentricity());
     const double mass_q = planet.get_mass() /
 			  data.get_planetary_system().get_planet(0).get_mass();
     const double compute_radius =
 	eggleton_1983(mass_q, planet.get_distance_to_primary());
-    const double scaling_factor = std::sqrt(planet.get_mass());
+    const double scaling_factor = std::sqrt(mass_q);
 
     const double min_dist = RMIN / 3.0;
 
@@ -689,15 +691,17 @@ void init_secondary_disk_energies(t_data &data)
     const auto &planet = data.get_planetary_system().get_planet(1);
     const double disk_size = parameters::profile_cutoff_point_outer *
 			     planet.get_dimensionless_roche_radius() /
-			     (1.0 - planet.get_dimensionless_roche_radius());
+			     (1.0 - planet.get_dimensionless_roche_radius())
+			     * planet.get_semi_major_axis() * (1.0 - planet.get_eccentricity());
     const double cutoff_width = parameters::profile_cutoff_width_outer *
 				planet.get_dimensionless_roche_radius() /
-				(1.0 - planet.get_dimensionless_roche_radius());
+				(1.0 - planet.get_dimensionless_roche_radius())
+				* planet.get_semi_major_axis() * (1.0 - planet.get_eccentricity());
     const double mass_q = planet.get_mass() /
 			  data.get_planetary_system().get_planet(0).get_mass();
     const double compute_radius =
 	eggleton_1983(mass_q, planet.get_distance_to_primary());
-    const double scaling_factor = std::sqrt(planet.get_mass());
+    const double scaling_factor = std::sqrt(mass_q);
 
     const double min_dist = RMIN / 3.0;
 


### PR DESCRIPTION
The size of the secondary disk in the primary oscillated with the smoothing length when on an eccentric orbit.
Because the smoothing length was defined over the distance to the primary. This has now been changed to the periastron distance, since that represents the maximum stable orbit.

Also gave a some units to the secondary disk init function, which before assumed binary mass = 1 and binary distance = 1.